### PR TITLE
Added support for mqtt authentication via username and password.

### DIFF
--- a/config/mqtt.properties
+++ b/config/mqtt.properties
@@ -29,5 +29,9 @@ tasks.max=1
 #mqtt.ssl.cert=null
 # Client key to use to connect to mqtt broker, can be used when connecting to TLS secured brokers - default `null`
 #mqtt.ssl.key=null
+# Username to use to connect to mqtt broker - default `null`
+#mqtt.username=null
+# Username to use to connect to mqtt broker - default `null`
+#mqtt.password=null
 # Message processor class to use to process mqtt messages before puting them on kafka - defaults to samle `DumbProcessor`
 #message_processor_class=com.evokly.kafka.connect.mqtt.sample.DumbProcessor

--- a/src/main/java/com/evokly/kafka/connect/mqtt/MqttSourceConnectorConfig.java
+++ b/src/main/java/com/evokly/kafka/connect/mqtt/MqttSourceConnectorConfig.java
@@ -56,6 +56,10 @@ public class MqttSourceConnectorConfig extends AbstractConfig {
                 .define(MqttSourceConstant.MQTT_SSL_PRIV_KEY, Type.STRING, null, Importance.LOW,
                         "cert priv key to use if using ssl",
                         "SSL", 3, ConfigDef.Width.LONG, "Key", MODE_SSL_RECOMMENDER)
+                .define(MqttSourceConstant.MQTT_USERNAME, Type.STRING, null, Importance.MEDIUM,
+                        "username to authenticate to mqtt broker")
+                .define(MqttSourceConstant.MQTT_PASSWORD, Type.STRING, null, Importance.MEDIUM,
+                        "password to authenticate to mqtt broker")
                 .define(MqttSourceConstant.MESSAGE_PROCESSOR, Type.CLASS,
                         DumbProcessor.class, Importance.HIGH,
                         "message processor to use");

--- a/src/main/java/com/evokly/kafka/connect/mqtt/MqttSourceConstant.java
+++ b/src/main/java/com/evokly/kafka/connect/mqtt/MqttSourceConstant.java
@@ -19,6 +19,8 @@ public class MqttSourceConstant {
     public static final String MQTT_SSL_CA_CERT = "mqtt.ssl.ca_cert";
     public static final String MQTT_SSL_CERT = "mqtt.ssl.cert";
     public static final String MQTT_SSL_PRIV_KEY = "mqtt.ssl.key";
+    public static final String MQTT_USERNAME = "mqtt.user";
+    public static final String MQTT_PASSWORD = "mqtt.password";
 
     public static final String MESSAGE_PROCESSOR = "message_processor_class";
 }

--- a/src/main/java/com/evokly/kafka/connect/mqtt/MqttSourceTask.java
+++ b/src/main/java/com/evokly/kafka/connect/mqtt/MqttSourceTask.java
@@ -105,6 +105,16 @@ public class MqttSourceTask extends SourceTask implements MqttCallback {
         connectOptions.setServerURIs(
                 mConfig.getString(MqttSourceConstant.MQTT_SERVER_URIS).split(","));
 
+        if (mConfig.getString(MqttSourceConstant.MQTT_USERNAME) != null) {
+            connectOptions.setUserName(
+                    mConfig.getString(MqttSourceConstant.MQTT_USERNAME));
+        }
+
+        if (mConfig.getString(MqttSourceConstant.MQTT_PASSWORD) != null) {
+            connectOptions.setPassword(
+                    mConfig.getString(MqttSourceConstant.MQTT_PASSWORD).toCharArray());
+        }
+
         // Connect to Broker
         try {
             // Address of the server to connect to, specified as a URI, is overridden using


### PR DESCRIPTION
This patch adds the ability to connect to an mqtt broker with authentication via username and password. For this, two new optional configuration options are added: "mqtt.username" and "mqtt.password".
If these configuration options are defined, they are used to authenticate to the mqtt server.
If these configuration options are not defined, the behaviour is the same as without this patch.