### PR TITLE
exclude connect-api jar in copyRuntimeLibs task

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,9 @@ tasks.withType(FindBugs) {
 
 task copyRuntimeLibs(type: Copy) {
     into "$buildDir/output/lib"
-    from configurations.runtime
+    from (configurations.runtime) {
+        exclude('connect-api*')
+    }
 }
 
 


### PR DESCRIPTION
connect-api jar is not required and causes problems when using kafka > 0.10.0.0 if included on the class path.